### PR TITLE
Minor typo/style fixes

### DIFF
--- a/scripts/create_rest_wsdls.js
+++ b/scripts/create_rest_wsdls.js
@@ -108,9 +108,9 @@ const createWsdl = (serviceUrl, filename) => {
 
   const isEnumUrl = (url) => {
     return (
-        url.search(/Enum.html$/) !== -1
-        || url.search(/OrderFulfillmentStatus.html$/) !== -1
-        || url.search(/FulfillmentInstructionsType.html$/) !== -1
+        url.search(/Enum.html$/) !== -1 ||
+        url.search(/OrderFulfillmentStatus.html$/) !== -1 ||
+        url.search(/FulfillmentInstructionsType.html$/) !== -1
     );
   };
 

--- a/scripts/create_rest_wsdls.js
+++ b/scripts/create_rest_wsdls.js
@@ -20,7 +20,7 @@ const createWsdl = (serviceUrl, filename) => {
         }
     } while (trys < MAX_RETRIES);
 
-    console.log(`To many retries for ${url}`);
+    console.log(`Too many retries for ${url}`);
     return null;
   };
 


### PR DESCRIPTION
Fix typo and fix the following warning:

```
./scripts/create_rest_wsdls.js: line 112, col 9, Misleading line break before '||'; readers may interpret this as an expression boundary.
./scripts/create_rest_wsdls.js: line 113, col 9, Misleading line break before '||'; readers may interpret this as an expression boundary.
```